### PR TITLE
增加Firefox适配并替换innerHTML注入代码的方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [Chrome Store安装](https://chrome.google.com/webstore/detail/%E5%93%94%E5%93%A9%E5%93%94%E5%93%A9%C2%B7%E7%8C%9C%E4%BD%A0%E5%96%9C%E6%AC%A2/ngjddnobeppdekpmimhiamkoonoaccdf)
 
+[Firefox版](https://addons.mozilla.org/zh-CN/firefox/addon/bili-guessyoulike/)
+
 制作本插件基于一个很常见的现象，就是虽然B站首页列了一万个视频，但是我一个都不想看！    
 每次都很羡慕app上的猜你喜欢，为什么PC上没有猜你喜欢啊！！          
 只能自己做一个了！！！（并没有

--- a/main.js
+++ b/main.js
@@ -1,8 +1,5 @@
 let activeTab = null; // 当前tab
 
-// 判断是否为firefox
-var isFirefox = typeof InstallTrigger !== 'undefined';
-
 // ajax
 const HTTP = {
 	get(url) {
@@ -231,7 +228,7 @@ const UI = {
 			// 插入新视频
 			videos.forEach((video) => {
 				node1 = document.createElement("img");
-				node1.src = video.pic+"@160w_100h."+(isFirefox&&"jpg"||"webp");
+				node1.src = video.pic+"@160w_100h.webp";
 				node2 = document.createElement("div");
 				node2.classList.add("lazy-img");
 				node2.appendChild(node1);

--- a/main.js
+++ b/main.js
@@ -1,5 +1,8 @@
 let activeTab = null; // 当前tab
 
+// 判断是否为firefox
+var isFirefox = typeof InstallTrigger !== 'undefined';
+
 // ajax
 const HTTP = {
 	get(url) {
@@ -200,7 +203,7 @@ const UI = {
 			}
 			// 插入新视频
 			videos.forEach((video) => {
-				let v = `<div class="spread-module"><a href="/video/av${video.aid}/" target="_blank"><div class="pic"><div class="lazy-img"><img src="${video.pic}@160w_100h.webp"></div></div><p title="${video.title}" class="t">${video.title}</p><p class="num"><span class="play"><i class="icon"></i>${toWan(video.stat.view)}</span><span class="danmu"><i class="icon"></i>${toWan(video.stat.danmaku)}</span></p></a></div>`;
+				let v = `<div class="spread-module"><a href="/video/av${video.aid}/" target="_blank"><div class="pic"><div class="lazy-img"><img src="${video.pic}@160w_100h.${isFirefox&&"jpg"||"webp"}"></div></div><p title="${video.title}" class="t">${video.title}</p><p class="num"><span class="play"><i class="icon"></i>${toWan(video.stat.view)}</span><span class="danmu"><i class="icon"></i>${toWan(video.stat.danmaku)}</span></p></a></div>`;
 				html += v;
 			});
 		} else {

--- a/main.js
+++ b/main.js
@@ -163,11 +163,21 @@ const UI = {
 		name.textContent = '猜你喜欢';
 		// 修改结构
 		let text = node.querySelector('.bili-tab');
-		text.innerHTML = '这是一个非官方的猜你喜欢模块，有任何建议或bug反馈请联系 <a href="https://weibo.com/chitosai" target="_blank">@千歳</a>';
+		while (text.hasChildNodes()) {
+			text.removeChild(text.firstChild);
+		}
+		text.textContent = '这是一个非官方的猜你喜欢模块，有任何建议或bug反馈请联系 ';
+		var info = document.createElement('a');
+		info.href = "https://weibo.com/chitosai";
+		info.target = "_blank";
+		info.textContent = "@千歳";
+		text.appendChild(info);
 		text.style.margin = '3px 0 0 0';
 		text.style.color = '#ccc';
 		let rank = node.querySelector('.sec-rank');
-		rank.innerHTML = '';
+		while (rank.hasChildNodes()) {
+			rank.removeChild(rank.firstChild);
+		}
 		rank.style.width = '80px';
 		rank.style.height = '530px';
 		rank.style.background = '#f0f0f0';
@@ -176,7 +186,13 @@ const UI = {
 		let btn = document.createElement('div');
 		btn.classList.add('read-push');
 		btn.style.marginLeft = '-5px';
-		btn.innerHTML = '<i class="icon icon_read"></i><span class="info">换一批</span>';
+		var btn_i = document.createElement("i");
+		var btn_s = document.createElement("span");
+		btn_i.classList.add("icon","icon_read");
+		btn_s.classList.add("info");
+		btn_s.textContent = "换一批";
+		btn.appendChild(btn_i);
+		btn.appendChild(btn_s);
 		// 点这个按钮就通知插件换一批推荐视频
 		btn.addEventListener('click', () => {
 			window.postMessage({
@@ -198,19 +214,61 @@ const UI = {
 		let stage = node.querySelector('.storey-box');
 		stage.style.height = '486px';
 		let html = '';
+		while (stage.hasChildNodes()) {
+			stage.removeChild(stage.firstChild);
+		}
 		if( videos.length ) {
 			function toWan(number) {
 				return number > 9999 ? ((number/10000).toFixed(1) + '万') : number;
 			}
 			// 插入新视频
 			videos.forEach((video) => {
-				let v = `<div class="spread-module"><a href="/video/av${video.aid}/" target="_blank"><div class="pic"><div class="lazy-img"><img src="${video.pic}@160w_100h.${isFirefox&&"jpg"||"webp"}"></div></div><p title="${video.title}" class="t">${video.title}</p><p class="num"><span class="play"><i class="icon"></i>${toWan(video.stat.view)}</span><span class="danmu"><i class="icon"></i>${toWan(video.stat.danmaku)}</span></p></a></div>`;
-				html += v;
+				node1 = document.createElement("img");
+				node1.src = video.pic+"@160w_100h."+(isFirefox&&"jpg"||"webp");
+				node2 = document.createElement("div");
+				node2.classList.add("lazy-img");
+				node2.appendChild(node1);
+				node3 = document.createElement("div");
+				node3.classList.add("pic");
+				node3.appendChild(node2);
+				node4 = document.createElement("a");
+				node4.href = "/video/av"+video.aid+"/";
+				node4.target = "_blank";
+				node4.appendChild(node3);
+				node5 = document.createElement("p");
+				node5.classList.add("t");
+				node5.title = video.title;
+				node5.textContent = video.title;
+				node4.appendChild(node5);
+				node6 = document.createElement("i");
+				node6.classList.add("icon");
+				node7 = document.createElement("span");
+				node7.classList.add("play");
+				node7.textContent = toWan(video.stat.view);
+				node7.insertBefore(node6,node7.firstChild);
+				node8 = document.createElement("i");
+				node8.classList.add("icon");
+				node9 = document.createElement("span");
+				node9.classList.add("danmu");
+				node9.textContent = toWan(video.stat.danmaku);
+				node9.insertBefore(node8,node9.firstChild);
+				node10 = document.createElement("p");
+				node10.classList.add("num");
+				node10.appendChild(node7);
+				node10.appendChild(node9);
+				node4.appendChild(node10);
+				node11 = document.createElement("div");
+				node11.classList.add("spread-module");
+				node11.appendChild(node4);
+				html = node11;
+				stage.appendChild(html);
 			});
 		} else {
-			html = '<p style="color: #777; line-height: 486px; text-align: center;">观看记录为空，快去看几个视频吧~</p>';
+			html = document.createElement("p");
+			html.style.cssText = "color: #777; line-height: 486px; text-align: center;";
+			html.textContent = "观看记录为空，快去看几个视频吧~";
+			stage.appendChild(html);
 		}
-		stage.innerHTML = html;
 	},
 	// 监听来自页面的更新请求
 	listen() {

--- a/main.js
+++ b/main.js
@@ -172,6 +172,13 @@ const UI = {
 		info.target = "_blank";
 		info.textContent = "@千歳";
 		text.appendChild(info);
+		var info2 = document.createTextNode("，Firefox版兼容性问题请反馈");
+		text.appendChild(info2);
+		var info2Link = document.createElement('a');
+		info2Link.href = "https://github.com/niu541412/bili-guessYouLike";
+		info2Link.target = "_blank";
+		info2Link.textContent = "至此";
+		text.appendChild(info2Link);
 		text.style.margin = '3px 0 0 0';
 		text.style.color = '#ccc';
 		let rank = node.querySelector('.sec-rank');

--- a/main.js
+++ b/main.js
@@ -119,9 +119,10 @@ const RECOMMAND = {
 				let ids = [], videos = [];
 				while( ids.length < max ) {
 					let i = Math.floor(Math.random() * allVideos.length);
-					if( !ids.includes(i) ) {
-						ids.push(i);
-						videos.push(allVideos[i]);
+					const v = allVideos[i];
+					if( !ids.includes(v.aid) ) {
+						ids.push(v.aid);
+						videos.push(v);
 					}
 				};
 				UI.updateRecommands(videos);

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "哔哩哔哩·猜你喜欢",
   "description": "为你的哔哩哔哩PC首页增加「猜你喜欢」模块",
-  "version": "1.5",
+  "version": "1.6",
 
   "browser_action": {
     "default_icon": "icon.png",
@@ -13,16 +13,17 @@
   "permissions": [
     "http://www.bilibili.com/*",
     "https://www.bilibili.com/*",
+    "https://comment.bilibili.com/*",
     "storage",
     "unlimitedStorage",
     "tabs"
   ],
-  "content_scripts":[{
-    "matches":[
+  "content_scripts": [{
+    "matches": [
       "http://www.bilibili.com/*",
       "https://www.bilibili.com/*"
     ],
-    "js":[
+    "js": [
       "main.js"
     ],
     "run_at": "document_idle"

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,11 @@
   "description": "为你的哔哩哔哩PC首页增加「猜你喜欢」模块",
   "version": "1.6",
 
+    "icons":{
+  	"16": "icon.png",
+  	"48":"icon.png",
+  	"128":"icon128.png"
+  },
   "browser_action": {
     "default_icon": "icon.png",
     "default_title": "哔哩哔哩猜你喜欢",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "哔哩哔哩·猜你喜欢",
   "description": "为你的哔哩哔哩PC首页增加「猜你喜欢」模块",
-  "version": "1.6.4",
+  "version": "1.6.5",
 
   "icons":{
   	"16": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "哔哩哔哩·猜你喜欢",
   "description": "为你的哔哩哔哩PC首页增加「猜你喜欢」模块",
-  "version": "1.6",
+  "version": "1.6.3",
 
   "icons":{
   	"16": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "description": "为你的哔哩哔哩PC首页增加「猜你喜欢」模块",
   "version": "1.6",
 
-    "icons":{
+  "icons":{
   	"16": "icon.png",
   	"48":"icon.png",
   	"128":"icon128.png"

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "哔哩哔哩·猜你喜欢",
   "description": "为你的哔哩哔哩PC首页增加「猜你喜欢」模块",
-  "version": "1.6.3",
+  "version": "1.6.4",
 
   "icons":{
   	"16": "icon.png",

--- a/popup.html
+++ b/popup.html
@@ -31,6 +31,9 @@
 	    margin: 0;
 	    text-align: center;
 		}
+		#clearStorage{
+			width: 50%;
+		}
 	</style>
 </head>
 <body>
@@ -43,7 +46,7 @@
 		<dd id="storageUsage"></dd>
 	</dl>
 	<p id="bottom">
-		<a id="clearStorage">清除缓存</a>
+		<button id="clearStorage">清除缓存</button>
 	</p>
 	<script src="popup.js"></script>
 </body>

--- a/popup.html
+++ b/popup.html
@@ -12,12 +12,12 @@
 			margin: 15px;
 		}
 		dl::after{
-			content: ""; 
-			display: block; 
-			clear: both; 
+			content: "";
+			display: block;
+			clear: both;
 		}
 		dt{
-			float: left;
+			position: absolute;
 		}
 		dd{
 			text-align: right;

--- a/popup.js
+++ b/popup.js
@@ -9,16 +9,32 @@ function init() {
 		document.querySelector('#videosCount').textContent = data['count'] || 0;
 	});
 
-	// 数据大小
-	chrome.storage.local.getBytesInUse(null, (bytes) => {
-		let d = 0;
-		if( bytes < 1048576 ) {
-			d = ( (bytes / 1024).toFixed(1) + 'KB');
-		} else {
-			d = ( (bytes / 1048576).toFixed(1) + 'MB');
-		}
-		document.querySelector('#storageUsage').textContent = d;
-	});
+  // 判断是否为firefox
+  var isFirefox = typeof InstallTrigger !== 'undefined';
+
+  // 数据大小
+  if(isFirefox) {
+    chrome.storage.local.get(null, (items) => {
+      bytes = JSON.stringify(items).length;
+      let d = 0;
+      if (bytes < 1048576) {
+        d = ((bytes / 1024).toFixed(1) + 'KB');
+      } else {
+        d = ((bytes / 1048576).toFixed(1) + 'MB');
+      }
+      document.querySelector('#storageUsage').textContent = d;
+    });
+  } else {
+    chrome.storage.local.getBytesInUse(null, (bytes) => {
+      let d = 0;
+      if( bytes < 1048576 ) {
+        d = ( (bytes / 1024).toFixed(1) + 'KB');
+      } else {
+        d = ( (bytes / 1048576).toFixed(1) + 'MB');
+      }
+      document.querySelector('#storageUsage').textContent = d;
+    });
+  }
 }
 
 init();


### PR DESCRIPTION
在我的机器上，最新版Firefox调试没问题。firefox商店审查后会下架使用innerHTML注入代码的插件。